### PR TITLE
fix(ci): correção processo deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,31 +12,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch all commits to get last updated time or other git log info
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          # choose pnpm version to use
-          version: 7
-          # install deps with pnpm
-          run_install: true
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          # choose node.js version to use
-          node-version: 18
+          # choose node.js version to use (20+ required by recent VuePress deps)
+          node-version: 20
           # cache deps for pnpm
           cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       # run build script
       - name: Build VuePress site
         run: pnpm docs:build
-      
+
       # run build script create file CNAME
       - name: Create file CNAME
         run: echo 'ceruttimaicon.js.org' > docs/.vuepress/dist/CNAME
@@ -44,7 +42,7 @@ jobs:
       # please check out the docs of the workflow for more details
       # @see https://github.com/crazy-max/ghaction-github-pages
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           # deploy to gh-pages branch
           target_branch: gh-pages

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "project-ceruttimaicon.github.io",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Projeto de documentaçao de comandos e metodologias uteis",
   "repository": "git@github.com:CeruttiMaicon/project-ceruttimaicon.github.io.git",
   "author": "Maicon Cerutti <dev.cerutti.maicon@gmail.com>",
   "license": "MIT",
+  "packageManager": "pnpm@10.32.1",
   "devDependencies": {
     "@vuepress/bundler-vite": "2.0.0-rc.28",
     "@vuepress/client": "2.0.0-rc.28",


### PR DESCRIPTION
> - [x] Lembrete: Em hotfix'es ajustar o package.json com a versão

### O que?

- Atualização de todas as dependências do projeto para as versões mais recentes compatíveis (migração do VuePress `2.0.0-beta.59` para `2.0.0-rc.28`).
- Adição do bundler `@vuepress/bundler-vite` (obrigatório a partir do `rc`) e remoção do `vite` standalone e do `@vuepress/shared-utils` (legado do VuePress 1.x).
- Atualização do `postcss` de `8.4.20` para `8.5.12`.
- Ajuste do `docs/.vuepress/config.js` para registrar o `viteBundler()` explicitamente.
- Correção dos itens do menu **Documentações** na navbar, que passaram a exibir os títulos legíveis (Amazon, Docker, Git, Laravel, etc.) em vez dos paths `.html`.
- Atualização do workflow `.github/workflows/docs.yml`:
  - `actions/checkout@v3` → `v4`
  - `pnpm/action-setup@v2` (pnpm 7) → `v4` (lê o `packageManager` do `package.json`)
  - `actions/setup-node@v3` (Node 18) → `v4` (Node 20)
  - `crazy-max/ghaction-github-pages@v2` → `v4`
  - Step de instalação separado e explícito (`pnpm install --frozen-lockfile`)
- Adição de `"packageManager": "pnpm@10.32.1"` no `package.json` para padronizar a versão do pnpm entre ambiente local e CI.
- Atualização do `README.md` com:
  - Tabela de tecnologias e versões.
  - Comandos de instalação e execução local com `pnpm`.
  - Documentação completa do fluxo de deploy automático: ao concluir o `git flow release finish`, o push na branch `main` dispara o GitHub Actions, que faz o build e publica o site na branch `gh-pages`.

### Por quê?

- A versão `beta.59` do VuePress estava desatualizada há bastante tempo e várias dependências indiretas já apresentavam alertas de descontinuação. Atualizar mantém o projeto seguro, com correções de bugs e compatível com o ecossistema atual do Vue 3.
- O workflow de deploy estava quebrando em produção com `SyntaxError: Invalid regular expression flags` porque o Node 18 não suporta a flag `/v` em regex (usada pela dependência `string-width@8`). A atualização para Node 20 resolve a causa raiz do erro.
- O pnpm `7` declarado no workflow não suporta o `lockfileVersion: '9.0'` gerado localmente pelo pnpm 10, o que causaria falhas de install no CI.
- O fluxo de deploy via Git Flow + GitHub Actions não estava documentado, o que dificultava o entendimento de como uma alteração chega em produção (`gh-pages`). Documentar deixa explícito para qualquer pessoa (ou para o "eu do futuro") como liberar uma nova versão do site.
- Os títulos quebrados na navbar (`/docs/amazon.html`, etc.) prejudicavam a navegação e a experiência do usuário no site publicado.

### Como?

- **Atualização das dependências:** verificadas as versões compatíveis via `npm info <pkg> peerDependencies`. Importante notar que o `@vuepress/theme-default` e os plugins do ecossistema VuePress utilizam um esquema de versionamento próprio (`rc.128`) diferente do core (`rc.28`), por isso as versões fixadas no `package.json` parecem desalinhadas — mas é o esperado segundo as peer deps oficiais.
- **Bundler explícito:** a partir do `rc`, o VuePress não embute mais um bundler por padrão. Foi adicionada a chamada `bundler: viteBundler()` no `config.js` em vez de usar Webpack, mantendo a compatibilidade com o build anterior.
- **Navbar:** os `children` da navbar foram convertidos de strings (paths) para objetos `{ text, link }`. No `rc`, quando apenas o path é fornecido e o `README.md` da pasta não tem frontmatter `title` ou heading `h1`, o VuePress acaba renderizando o próprio path. Definir `text` explicitamente garante o título correto.
- **CI:** ao usar `pnpm/action-setup@v4` sem `version` explícito, a action lê automaticamente o campo `packageManager` do `package.json`, garantindo paridade entre ambiente local e CI. O step de install foi separado para seguir o padrão recomendado pela action moderna.
- **Build validado localmente:** `pnpm docs:build` executa com sucesso (52 páginas renderizadas).

### Capturas de tela

> Adicionar antes/depois da navbar **Documentações** mostrando os títulos legíveis no lugar dos paths `.html`.

### Verificações

- [x] HOTFIX Verificar versão no PACKAGE.JSON
