### PR TITLE
feat(segurança): atualizações das versões dos pacotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,11 @@
   "dependencies": {
     "@vuepress/plugin-search": "2.0.0-rc.128",
     "postcss": "8.5.12"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": ">=4.2.0",
+      "esbuild": ">=0.28.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,32 +4,36 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: '>=4.2.0'
+  esbuild: '>=0.28.1'
+
 importers:
 
   .:
     dependencies:
       '@vuepress/plugin-search':
         specifier: 2.0.0-rc.128
-        version: 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+        version: 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       postcss:
         specifier: 8.5.12
         version: 8.5.12
     devDependencies:
       '@vuepress/bundler-vite':
         specifier: 2.0.0-rc.28
-        version: 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+        version: 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
       '@vuepress/client':
         specifier: 2.0.0-rc.28
-        version: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+        version: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/theme-default':
         specifier: 2.0.0-rc.128
-        version: 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(sass@1.99.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+        version: 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(sass@1.99.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       vue:
         specifier: ^3.5.38
         version: 3.5.38
       vuepress:
         specifier: 2.0.0-rc.28
-        version: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+        version: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
 
 packages:
 
@@ -89,158 +93,158 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -898,9 +902,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1037,8 +1038,8 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
-  electron-to-chromium@1.5.374:
-    resolution: {integrity: sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==}
+  electron-to-chromium@1.5.375:
+    resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -1060,19 +1061,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -1186,8 +1182,8 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1513,9 +1509,6 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
@@ -1620,7 +1613,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1792,82 +1785,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2205,10 +2198,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
       vue: 3.5.38
 
   '@vue-macros/common@3.1.2(vue@3.5.38)':
@@ -2288,12 +2281,12 @@ snapshots:
 
   '@vue/shared@3.5.38': {}
 
-  '@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)':
+  '@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)':
     dependencies:
-      '@vitejs/plugin-vue': 6.0.7(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
-      '@vuepress/bundlerutils': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
-      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
-      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+      '@vitejs/plugin-vue': 6.0.7(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      '@vuepress/bundlerutils': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/shared': 2.0.0-rc.28
       '@vuepress/utils': 2.0.0-rc.28
       autoprefixer: 10.5.0(postcss@8.5.12)
@@ -2301,9 +2294,9 @@ snapshots:
       postcss: 8.5.12
       postcss-load-config: 6.0.1(postcss@8.5.12)(yaml@2.9.0)
       rolldown: 1.1.1
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
       vue: 3.5.38
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@pinia/colada'
       - '@types/node'
@@ -2323,14 +2316,14 @@ snapshots:
       - typescript
       - yaml
 
-  '@vuepress/bundlerutils@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))':
+  '@vuepress/bundlerutils@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
-      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
-      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/shared': 2.0.0-rc.28
       '@vuepress/utils': 2.0.0-rc.28
       vue: 3.5.38
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@pinia/colada'
       - '@vue/compiler-sfc'
@@ -2339,15 +2332,15 @@ snapshots:
       - typescript
       - vite
 
-  '@vuepress/cli@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))':
+  '@vuepress/cli@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
-      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/shared': 2.0.0-rc.28
       '@vuepress/utils': 2.0.0-rc.28
       cac: 7.0.0
       chokidar: 5.0.0
       envinfo: 7.21.0
-      esbuild: 0.27.7
+      esbuild: 0.28.1
     transitivePeerDependencies:
       - '@pinia/colada'
       - '@vue/compiler-sfc'
@@ -2356,13 +2349,13 @@ snapshots:
       - typescript
       - vite
 
-  '@vuepress/client@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))':
+  '@vuepress/client@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
       '@vue/devtools-api': 8.1.3
       '@vue/devtools-kit': 8.1.3
       '@vuepress/shared': 2.0.0-rc.28
       vue: 3.5.38
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@pinia/colada'
       - '@vue/compiler-sfc'
@@ -2370,9 +2363,9 @@ snapshots:
       - typescript
       - vite
 
-  '@vuepress/core@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))':
+  '@vuepress/core@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
-      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/markdown': 2.0.0-rc.28
       '@vuepress/shared': 2.0.0-rc.28
       '@vuepress/utils': 2.0.0-rc.28
@@ -2385,7 +2378,7 @@ snapshots:
       - typescript
       - vite
 
-  '@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
       '@vue/shared': 3.5.38
       '@vueuse/core': 14.3.0(vue@3.5.38)
@@ -2393,16 +2386,16 @@ snapshots:
       fflate: 0.8.3
       gray-matter: 4.0.3
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     optionalDependencies:
-      '@vuepress/bundler-vite': 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+      '@vuepress/bundler-vite': 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/highlighter-helper@2.0.0-rc.128(@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/highlighter-helper@2.0.0-rc.128(@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     optionalDependencies:
       '@vueuse/core': 14.3.0(vue@3.5.38)
 
@@ -2427,68 +2420,68 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vuepress/plugin-active-header-links@2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-active-header-links@2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.5.38)
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-back-to-top@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-back-to-top@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       '@vueuse/core': 14.3.0(vue@3.5.38)
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
-    transitivePeerDependencies:
-      - '@vuepress/bundler-vite'
-      - '@vuepress/bundler-webpack'
-      - typescript
-
-  '@vuepress/plugin-copy-code@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
-    dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vueuse/core': 14.3.0(vue@3.5.38)
-      vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-git@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-copy-code@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vueuse/core': 14.3.0(vue@3.5.38)
+      vue: 3.5.38
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+    transitivePeerDependencies:
+      - '@vuepress/bundler-vite'
+      - '@vuepress/bundler-webpack'
+      - typescript
+
+  '@vuepress/plugin-git@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+    dependencies:
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       '@vueuse/core': 14.3.0(vue@3.5.38)
       rehype-parse: 9.0.1
       rehype-sanitize: 6.0.0
       rehype-stringify: 10.0.1
       unified: 11.0.5
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-links-check@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-links-check@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-markdown-hint@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vue@3.5.38)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-markdown-hint@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vue@3.5.38)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
       '@mdit/plugin-alert': 0.23.2(markdown-it@14.2.0)
       '@mdit/plugin-container': 0.23.2(markdown-it@14.2.0)
       '@types/markdown-it': 14.1.2
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       '@vueuse/core': 14.3.0(vue@3.5.38)
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
@@ -2496,98 +2489,98 @@ snapshots:
       - typescript
       - vue
 
-  '@vuepress/plugin-markdown-tab@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-markdown-tab@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
       '@mdit/plugin-tab': 0.24.2(markdown-it@14.2.0)
       '@types/markdown-it': 14.1.2
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       '@vueuse/core': 14.3.0(vue@3.5.38)
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - markdown-it
       - typescript
 
-  '@vuepress/plugin-medium-zoom@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-medium-zoom@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       medium-zoom: 1.1.0
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-nprogress@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-nprogress@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-palette@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-palette@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       chokidar: 5.0.0
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-prismjs@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-prismjs@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/highlighter-helper': 2.0.0-rc.128(@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/highlighter-helper': 2.0.0-rc.128(@vuepress/helper@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       prismjs: 1.30.0
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - '@vueuse/core'
       - typescript
 
-  '@vuepress/plugin-search@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-search@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       chokidar: 5.0.0
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-seo@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-seo@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-sitemap@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-sitemap@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       sitemap: 9.0.1
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
       - '@vuepress/bundler-webpack'
       - typescript
 
-  '@vuepress/plugin-theme-data@2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/plugin-theme-data@2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
       '@vue/devtools-api': 8.1.3
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     transitivePeerDependencies:
       - typescript
 
@@ -2595,26 +2588,26 @@ snapshots:
     dependencies:
       '@mdit-vue/types': 3.0.2
 
-  '@vuepress/theme-default@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(sass@1.99.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
+  '@vuepress/theme-default@2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(sass@1.99.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-active-header-links': 2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-back-to-top': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-copy-code': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-git': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-links-check': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-markdown-hint': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vue@3.5.38)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-markdown-tab': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-medium-zoom': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-nprogress': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-palette': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-prismjs': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-seo': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-sitemap': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
-      '@vuepress/plugin-theme-data': 2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/helper': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-active-header-links': 2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-back-to-top': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-copy-code': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-git': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-links-check': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-markdown-hint': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vue@3.5.38)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-markdown-tab': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(markdown-it@14.2.0)(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-medium-zoom': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-nprogress': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-palette': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-prismjs': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(@vueuse/core@14.3.0(vue@3.5.38))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-seo': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-sitemap': 2.0.0-rc.128(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
+      '@vuepress/plugin-theme-data': 2.0.0-rc.128(vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38))
       '@vueuse/core': 14.3.0(vue@3.5.38)
       vue: 3.5.38
-      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
+      vuepress: 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38)
     optionalDependencies:
       sass: 1.99.0
     transitivePeerDependencies:
@@ -2660,10 +2653,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   ast-kit@2.2.0:
@@ -2698,7 +2687,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.37
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.374
+      electron-to-chromium: 1.5.375
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -2802,7 +2791,7 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  electron-to-chromium@1.5.374: {}
+  electron-to-chromium@1.5.375: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -2817,38 +2806,36 @@ snapshots:
 
   envinfo@7.21.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
-
-  esprima@4.0.1: {}
 
   estree-walker@2.0.2: {}
 
@@ -2883,7 +2870,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2980,10 +2967,9 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@4.2.0:
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 
@@ -3323,8 +3309,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  sprintf-js@1.0.3: {}
-
   stdin-discarder@0.3.2: {}
 
   string-width@8.2.1:
@@ -3434,7 +3418,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3443,12 +3427,12 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       sass: 1.99.0
       yaml: 2.9.0
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.38)
@@ -3470,7 +3454,7 @@ snapshots:
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.38
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
 
   vue@3.5.38:
     dependencies:
@@ -3480,17 +3464,17 @@ snapshots:
       '@vue/server-renderer': 3.5.38(vue@3.5.38)
       '@vue/shared': 3.5.38
 
-  vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38):
+  vuepress@2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(@vuepress/bundler-vite@2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.38):
     dependencies:
-      '@vuepress/cli': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
-      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
-      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/cli': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/client': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vuepress/core': 2.0.0-rc.28(@vue/compiler-sfc@3.5.38)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0))
       '@vuepress/markdown': 2.0.0-rc.28
       '@vuepress/shared': 2.0.0-rc.28
       '@vuepress/utils': 2.0.0-rc.28
       vue: 3.5.38
     optionalDependencies:
-      '@vuepress/bundler-vite': 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.9.0)
+      '@vuepress/bundler-vite': 2.0.0-rc.28(@types/node@25.9.3)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(sass@1.99.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@pinia/colada'
       - '@vue/compiler-sfc'


### PR DESCRIPTION
### O que?
Adicionada a seção pnpm.overrides no package.json para forçar versões seguras de duas dependências transitivas vulneráveis: esbuild e js-yaml.

### Por quê?
O GitHub reportou duas vulnerabilidades de segurança detectadas no pnpm-lock.yaml:


esbuild >= 0.27.3 < 0.28.1 — GHSA-gv7w-rqvm-qjhr (High) e GHSA-g7r4-m6w7-qqqr (Low): permite leitura arbitrária de arquivos via servidor de desenvolvimento.

js-yaml <= 4.1.1 — CVE-2026-53550 (Moderate): DoS por complexidade quadrática no processamento de merge keys com aliases repetidos.

Ambas são dependências transitivas do @vuepress/bundler-vite, ou seja, não são declaradas diretamente no projeto. O simples pnpm upgrade não as atualiza porque o VuePress fixa suas versões internamente.

### Como?
Como não é possível atualizar as dependências transitivas diretamente via package.json, foi utilizado o mecanismo nativo do pnpm de overrides, que força uma versão mínima para pacotes em qualquer nível da árvore de dependências:

```json
"pnpm": {
  "overrides": {
    "js-yaml": ">=4.2.0",
    "esbuild": ">=0.28.1"
  }
}
```
Após o `pnpm install` com os overrides, pnpm audit retornou "No known vulnerabilities found".
